### PR TITLE
chore: renamed a let for a const

### DIFF
--- a/hooks/test/useFakeUserList.js
+++ b/hooks/test/useFakeUserList.js
@@ -8,7 +8,7 @@ export const useFakeUserList = () => {
 
   useEffect(() => {
     function generateUsers() {
-      let users = [];
+      const users = [];
       for (let id = 1; id <= 1000; id++) {
         users.push(createRandomUser());
       }


### PR DESCRIPTION
the var `users` is an array being filled, so no need to use let.