### PR TITLE
bug: reusing the file upload functionality left hanging two variables that need to be reset

### DIFF
--- a/components/directory/VirtualizedUserList.tsx
+++ b/components/directory/VirtualizedUserList.tsx
@@ -13,12 +13,6 @@ import { useFirebaseUsers } from "@/hooks/user_directory/useFirebaseUsers";
 import { useRouter } from "next/router";
 
 export type Ref = HTMLUListElement
-//
-// const Footer = () => (
-//   <div className="flex justify-center px-6 py-5 text-xs text-slate-400">
-//     Ha llegado al final de la lista.
-//   </div>
-// );
 
 
 // eslint-disable-next-line no-unused-vars

--- a/components/messaging/EditorWithAttachments.tsx
+++ b/components/messaging/EditorWithAttachments.tsx
@@ -3,7 +3,7 @@ import { FaceSmileIcon, PaperAirplaneIcon } from "@heroicons/react/24/outline";
 import { Editor } from "@tiptap/react";
 import { MyCustomEditor } from "@/components/messaging/MyCustomEditor";
 
-export const EditorWithAttachments = ({ editor }: { editor: Editor }) => {
+export const EditorWithAttachments = ({ editor }: { editor: Editor | null }) => {
 
   return (
     <div className="mt-12 px-2">

--- a/components/messaging/carousel/CarouselSlider.tsx
+++ b/components/messaging/carousel/CarouselSlider.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 
 import Image from "next/image";
 import { ShowFileTypeIcon } from "@/components/messaging/carousel/ShowFileTypeIcon";
+import { UploadedFile } from "@/interfaces/index"
 import { classNames } from "@/utils/classNames";
 import { deleteStorageFile } from "@/utils/deleteStorageFile";
 import { splitFileName } from "@/utils/splitFileName";
@@ -12,9 +13,15 @@ import { useCallback } from "react";
 import { useDropAndUploadFiles } from "@/hooks/fileUploader/useDropAndUploadFiles";
 import { useHoverFile } from "@/hooks/fileUploader/useHoverFile";
 
+type CarouselSliderProps = {
+  // eslint-disable-next-line no-unused-vars
+  handleSelectedFile: (file: UploadedFile) => void;
+  selectedImage: string | null;
+}
 //
-export const CarouselSlider = ({ handleSelectedFile, selectedImage }) => {
+export const CarouselSlider = ({ handleSelectedFile, selectedImage }: CarouselSliderProps) => {
   const uploadedImages = useAtomValue(uploadedFilesAtom);
+
   const setUploadedImages = useSetAtom(uploadedFilesAtom);
   const { isCurrentHoveredFile, handleMouseOver, handleMouseLeave } =
     useHoverFile();
@@ -22,13 +29,12 @@ export const CarouselSlider = ({ handleSelectedFile, selectedImage }) => {
 
   const handleRemoveFile = useAtomCallback(
     useCallback(
-      (get, set, arg) => {
+      (get, set, arg: { id: string, type: string, name: string }) => {
         const remainingImages = get(uploadedFilesAtom).filter(
           (file) => file.id !== arg.id
         );
 
         if (remainingImages) {
-          // async function to delete the recently uploaded file...
           !arg.type.startsWith("image/")
             ? deleteStorageFile(arg?.name, "documents")
             : deleteStorageFile(arg?.name, "images");
@@ -97,7 +103,8 @@ export const CarouselSlider = ({ handleSelectedFile, selectedImage }) => {
           </li>
         ))}
       </ul>
-      {uploadedImages[0]?.type.startsWith("image/") ? (
+      {uploadedImages.length > 0 &&
+        uploadedImages[0]?.type.startsWith("image/") ? (
         <div className="h-14 self-start">
           <button
             {...imageDropZone.getRootProps()}

--- a/components/messaging/carousel/CarouselWrapper.tsx
+++ b/components/messaging/carousel/CarouselWrapper.tsx
@@ -33,7 +33,9 @@ export const CarouselWrapper = () => {
 
   return (
     <Transition
-      show={Boolean(numberOfFilesUploaded > 0)}
+      show={Boolean(
+        uploadedImages.length > 0 || progress > 0 || numberOfFilesUploaded > 0
+      )}
       enter="transition-opacity duration-75"
       enterFrom="opacity-0"
       enterTo="opacity-100"
@@ -58,10 +60,10 @@ export const CarouselWrapper = () => {
             </button>
           </div>
           <div className="relative h-[60vh] w-full">
-            {isFileTypeAnImage(uploadedImages) ? (
+            {progress > 0 && isFileTypeAnImage(uploadedImages, selectedImage) ? (
               <Image
                 className="absolute top-0 h-full w-full rounded-sm object-contain drop-shadow-md"
-                src={currentSelectedFile(uploadedImages, selectedImage)?.url}
+                src={currentSelectedFile(uploadedImages, selectedImage)}
                 alt="file preview"
                 fill
                 sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 800px"
@@ -88,6 +90,7 @@ export const CarouselWrapper = () => {
                 </p>
               </div>
             )}
+
           </div>
           <div>
             {`${progress}%`}

--- a/hooks/fileUploader/useSelectedUploadedFile.ts
+++ b/hooks/fileUploader/useSelectedUploadedFile.ts
@@ -1,26 +1,26 @@
-import { useCallback, useState } from "react";
+import { selectedImageIdAtom, uploadedFilesAtom } from "@/lib/state/atoms";
 
 import { UploadedFile } from "@/interfaces/index";
-import { uploadedFilesAtom } from "@/lib/state/atoms";
+import { useAtom } from "jotai";
 import { useAtomCallback } from "jotai/utils";
-import { useAtomValue } from "jotai";
+import { useCallback } from "react";
 
-//
 export const useSelectedUploadedFile = () => {
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
-  const [selectedImage, setSelectedImage] = useState(
-    uploadedImages[0]?.id || null
-  );
+  const [selectedImage, setSelectedImage] = useAtom(selectedImageIdAtom);
 
   const handleSelectedFile = useAtomCallback(
-    useCallback((get, set, arg: UploadedFile) => {
-      const index = get(uploadedFilesAtom).findIndex(
-        (file: UploadedFile) => file.id === arg.id
-      );
-      if (index > -1) {
-        setSelectedImage(arg.id);
-      }
-    }, [])
+    useCallback(
+      (get, set, arg: UploadedFile) => {
+        const index = get(uploadedFilesAtom).findIndex(
+          (file: UploadedFile) => file.id === arg.id
+        );
+        if (index > -1) {
+          // eslint-disable-next-line no-unused-vars
+          (setSelectedImage as (value: string | null) => void)(arg.id);
+        }
+      },
+      [setSelectedImage]
+    )
   );
 
   return { handleSelectedFile, selectedImage };

--- a/hooks/fileUploader/useUploadFilesWithProgressFeedback.ts
+++ b/hooks/fileUploader/useUploadFilesWithProgressFeedback.ts
@@ -12,6 +12,7 @@ import { useSetAtom } from "jotai";
 export const useUploadFilesWithProgressFeedback = () => {
   const setProgressPercentage = useSetAtom(progressPercentageAtom);
   const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
+  // I'm not too sure about this, think about it
   const fileUploadOrder: number[] = [];
   //
   const uploadFilesToCloud = async (files: FileLike[], refPath: string) => {
@@ -35,8 +36,6 @@ export const useUploadFilesWithProgressFeedback = () => {
                 const progress = Math.round(
                   (snapshot.bytesTransferred / snapshot.totalBytes) * 100
                 );
-
-                // console.log(`Upload is ${progress}% done`);
                 setProgressPercentage(progress);
               },
               (error) => {

--- a/hooks/insurance_company/useCreateNewCompany.ts
+++ b/hooks/insurance_company/useCreateNewCompany.ts
@@ -1,3 +1,9 @@
+import {
+  numberOfFilesUploadedAtom,
+  progressPercentageAtom,
+  uploadedFilesAtom,
+} from "@/lib/state/atoms";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useState } from "react";
 
 import { InsuranceCompany } from "@/interfaces/index";
@@ -5,8 +11,6 @@ import { createInsuranceCompany } from "@/lib/insurance_company/createInsuranceC
 import { failureNotification } from "@/components/notifications/failureNotification";
 import { normalizeString } from "@/utils/normalizeString";
 import { successNotification } from "@/components/notifications/successNotification";
-import { uploadedFilesAtom } from "@/lib/state/atoms";
-import { useAtomValue,useSetAtom } from "jotai";
 import { useForm } from "react-hook-form";
 
 //
@@ -15,6 +19,8 @@ export const useCreateNewCompany = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [openModal, setOpenModal] = useState(false);
   const setUploadedImages = useSetAtom(uploadedFilesAtom);
+  const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
+  const setProgressPercentage = useSetAtom(progressPercentageAtom);
   const {
     register,
     reset,
@@ -46,6 +52,8 @@ export const useCreateNewCompany = () => {
     })
       .then(() => {
         reset();
+        setNumberOfFilesUploaded(0);
+        setProgressPercentage(0);
         setUploadedImages([]);
         handleCloseModal();
         setIsSubmitting(false);
@@ -54,6 +62,8 @@ export const useCreateNewCompany = () => {
         );
       })
       .catch((err) => {
+        setNumberOfFilesUploaded(0);
+        setProgressPercentage(0);
         setUploadedImages([]);
         handleCloseModal();
         setIsSubmitting(false);

--- a/hooks/insurance_company/useUpdateCompany.ts
+++ b/hooks/insurance_company/useUpdateCompany.ts
@@ -1,6 +1,8 @@
 import {
   isSubmittingAtom,
+  numberOfFilesUploadedAtom,
   openModalAtom,
+  progressPercentageAtom,
   selectedInsuranceCompanyAtom,
   uploadedFilesAtom,
 } from "@/lib/state/atoms";
@@ -23,6 +25,8 @@ export const useUpdateCompany = () => {
   const setUploadedImages = useSetAtom(uploadedFilesAtom);
   const setSelectedInsuranceCompany = useSetAtom(selectedInsuranceCompanyAtom);
   const selectedInsuranceCompany = useAtomValue(selectedInsuranceCompanyAtom);
+  const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
+  const setProgressPercentage = useSetAtom(progressPercentageAtom);
 
   const {
     register,
@@ -74,6 +78,8 @@ export const useUpdateCompany = () => {
     updateInsuranceCompany(updatedCom, updatedCompany.id)
       .then(() => {
         reset();
+        setNumberOfFilesUploaded(0);
+        setProgressPercentage(0);
         setUploadedImages([]);
         handleCloseModal();
         setIsSubmitting(false);
@@ -84,6 +90,8 @@ export const useUpdateCompany = () => {
         );
       })
       .catch((err) => {
+        setNumberOfFilesUploaded(0);
+        setProgressPercentage(0);
         setUploadedImages([]);
         handleCloseModal();
         setIsSubmitting(false);

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -158,7 +158,7 @@ export type DocumentType = {
   "application/rtf": [".rtf"];
 };
 
-export type FileLike = File & { preview?: string; id: string };
+export type FileLike = File & { preview?: string; id: string; url?: string };
 export type ImagesArray = FileLike[];
 export type UploadedFile = FileLike & {
   url: string;

--- a/lib/state/atoms.ts
+++ b/lib/state/atoms.ts
@@ -1,6 +1,5 @@
 import {
   IdentifiedUser,
-  ImagesArray,
   InsuranceCompany,
   RealUser,
   UploadedFile,
@@ -33,10 +32,11 @@ export const editorAtomwithImages = atom<Editor | null>(null);
 export const progressPercentageAtom = atom(0);
 export const numberOfFilesUploadedAtom = atom(0);
 export const uploadedFilesAtom = atom<UploadedFile[]>([]);
-export const fileOrImageAtom = atom<ImagesArray | []>([]);
-export const additionalFilesOrImagesAtom = atom<ImagesArray | []>([]);
-export const allFilesAtom = atom<ImagesArray | []>([]);
-export const selectedImageIdAtom = atom<string | null>(null);
+export const selectedImageIdAtom = atom<string | null>((get) => {
+  const uploadedFilesUrls = get(uploadedFilesAtom);
+  return uploadedFilesUrls[0]?.id || null;
+});
+
 export const selectedInsuranceCompanyAtom = atom<InsuranceCompany | null>(null);
 export const isSubmittingAtom = atom<boolean>(false);
 export const openModalAtom = atom<boolean>(false);

--- a/utils/calculateFileSize.ts
+++ b/utils/calculateFileSize.ts
@@ -2,7 +2,7 @@ import { ImagesArray } from "@/interfaces/index";
 
 export const calculateFileSize = (
   files: ImagesArray,
-  selectedImgId: string
+  selectedImgId: string | null
 ) => {
   if (files && files.length > 0) {
     const currentSelectedFile = files.find((file) => file.id === selectedImgId);

--- a/utils/currentSelectedFile.ts
+++ b/utils/currentSelectedFile.ts
@@ -2,15 +2,13 @@ import { ImagesArray } from "@/interfaces/index";
 
 export const currentSelectedFile = (
   files: ImagesArray,
-  selectedImgId: string
-) => {
+  selectedImgId: string | null
+): string => {
   const isSelected = files.find((file) => file.id === selectedImgId);
 
-  if (files && files.length > 0) {
-    if (isSelected === undefined) {
-      return files[0];
-    } else {
-      return isSelected;
-    }
+  if (isSelected === undefined) {
+    return files[0].url;
+  } else {
+    return isSelected.url;
   }
 };

--- a/utils/getFileExtensionFromName.ts
+++ b/utils/getFileExtensionFromName.ts
@@ -4,15 +4,13 @@ import { splitFileName } from "@/utils/splitFileName";
 //
 export const getFileExtensionFromName = (
   files: ImagesArray,
-  selectedImgId: string
-) => {
+  selectedImgId: string | null
+): string => {
   const currentSelectedFile = files.find((file) => file.id === selectedImgId);
 
-  if (files && files.length > 0) {
-    if (currentSelectedFile) {
-      return splitFileName(currentSelectedFile.name)?.toLocaleLowerCase();
-    } else {
-      return splitFileName(files[0].name)?.toLocaleLowerCase();
-    }
+  if (currentSelectedFile) {
+    return splitFileName(currentSelectedFile.name)?.toLocaleLowerCase();
+  } else {
+    return splitFileName(files[0]?.name)?.toLocaleLowerCase();
   }
 };

--- a/utils/getNameFromFile.ts
+++ b/utils/getNameFromFile.ts
@@ -1,15 +1,17 @@
 import { ImagesArray } from "@/interfaces/index";
 
-export const getNameFromFile = (files: ImagesArray, selectedImgId: string) => {
-  const currentSelectedFile = files.find((file) => file.id === selectedImgId);
+export const getNameFromFile = (
+  files: ImagesArray,
+  selectedImgId: string | null
+) => {
+  if (!files) return;
+  const currentSelectedFile = files?.find((file) => file?.id === selectedImgId);
   const splitFileName = (fileName: string) =>
-    fileName.split(".").slice(0, -1).join(".");
+    fileName?.split(".")?.slice(0, -1)?.join(".");
 
-  if (files && files.length > 0) {
-    if (currentSelectedFile) {
-      return splitFileName(currentSelectedFile.name);
-    } else {
-      return splitFileName(files[0].name);
-    }
+  if (currentSelectedFile) {
+    return splitFileName(currentSelectedFile?.name);
+  } else {
+    return splitFileName(files[0]?.name);
   }
 };

--- a/utils/isFileTypeAnImage.ts
+++ b/utils/isFileTypeAnImage.ts
@@ -2,7 +2,7 @@ import { ImagesArray } from "@/interfaces/index";
 
 export const isFileTypeAnImage = (
   files: ImagesArray,
-  selectedImgId: string
+  selectedImgId: string | null
 ) => {
   const isFileTypeAnImage = (str: string, type: string) => str.startsWith(type);
   const isSelectedImage = (arr: ImagesArray) =>

--- a/utils/splitFileName.ts
+++ b/utils/splitFileName.ts
@@ -1,3 +1,8 @@
-export const splitFileName = (fileName: string) => {
-  return fileName.split(".").pop();
+export const splitFileName = (fileName: string): string => {
+  if (!fileName) return "";
+  const fileNameSplitted = fileName.split(".");
+  if (fileNameSplitted.length > 0) {
+    return fileNameSplitted[fileNameSplitted.length - 1];
+  }
+  return fileName;
 };


### PR DESCRIPTION
So, the two hooks in charge of updating and creating insurance companies were re-using the same functionality (aka. same hooks) to upload an image for the insurance company logo.
This upload files hooks use two hooks that are "global" atoms and their values are used conditionally to show or hide a Transition when uploading images or documents from a User's Conversation Chat Window. 

By ensuring that the progress `progressPercentageAtom` and `numberOfFilesUploadedAtom` atoms variables are set back to their initial value (zero) we will NOT find the "bug" when going back to any user's conversation.