### PR TITLE
bug: selecting new user with no messages no longer shows msgs from previous user

### DIFF
--- a/components/messaging/Conversation.tsx
+++ b/components/messaging/Conversation.tsx
@@ -12,6 +12,7 @@ export const Conversation = ({ isLoading, error }: { isLoading: boolean, error: 
   const messagesFromDB = useAtomValue(messagesAtom)
 
 
+
   if (isLoading) {
     return (
       <div className="grid h-screen place-items-center overflow-hidden">
@@ -28,7 +29,7 @@ export const Conversation = ({ isLoading, error }: { isLoading: boolean, error: 
     );
   }
 
-  if (!messagesFromDB || messagesFromDB.length === 0) {
+  if (!messagesFromDB) {
     return (
       <div className="grid h-screen place-items-center overflow-hidden">
         <div className="bg-white px-6 py-24 sm:py-32 lg:px-8">


### PR DESCRIPTION
This was pretty fast to fix (hopefully 😅) but a little hard to detect since I haven't entered users with no message history after so many changes in this important functionality.

Basically when you selected a user with message history, and the another user with no message history, it was still showing you the messages from the previous user, all because the  `messagesAtom` atom that holds the messsage history was not being set back to an empty array when changing to a user with no message history.

So now, if a user has no message history (aka no messages in the db and nothing from twilio history api as well) this will be considered a new conversation. 


