### PR TITLE
bug fix: The progress var wasn't being set back to zero if all uploaded files were deleted

### DIFF
--- a/components/companies/DragAndDrop.tsx
+++ b/components/companies/DragAndDrop.tsx
@@ -13,12 +13,12 @@ export const DragAndDrop = () => {
   const selectedInsuranceCompany = useAtomValue(selectedInsuranceCompanyAtom);
   const { insuranceLogoDropZone } = useDropAndUploadFiles();
   const handleDeleteAllFiles = useDeleteAllUploadedFiles()
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
+  const uploadedResources = useAtomValue(uploadedFilesAtom);
   const ifUserUploadsALogo =
     !insuranceLogoDropZone.isDragActive &&
-    uploadedImages &&
-    uploadedImages.length > 0 &&
-    uploadedImages.map((file) => (
+    uploadedResources &&
+    uploadedResources.length > 0 &&
+    uploadedResources.map((file) => (
       <div className="relative h-auto w-full" key={file.name}>
         <Image
           className="h-full w-full object-contain"
@@ -108,7 +108,7 @@ export const DragAndDrop = () => {
               )}
             </div>
           </div>
-          {!insuranceLogoDropZone.isDragActive && uploadedImages && uploadedImages.length > 0 && (
+          {!insuranceLogoDropZone.isDragActive && uploadedResources && uploadedResources.length > 0 && (
             <button
               onClick={handleDeleteAllFiles}
               type="button"

--- a/components/messaging/carousel/CarouselSlider.tsx
+++ b/components/messaging/carousel/CarouselSlider.tsx
@@ -1,55 +1,36 @@
 import { PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useAtomValue, useSetAtom } from "jotai";
 
 import Image from "next/image";
 import { ShowFileTypeIcon } from "@/components/messaging/carousel/ShowFileTypeIcon";
-import { UploadedFile } from "@/interfaces/index"
+import { UploadedFile } from "@/interfaces/index";
 import { classNames } from "@/utils/classNames";
-import { deleteStorageFile } from "@/utils/deleteStorageFile";
 import { splitFileName } from "@/utils/splitFileName";
 import { uploadedFilesAtom } from "@/lib/state/atoms";
-import { useAtomCallback } from "jotai/utils";
-import { useCallback } from "react";
+import { useAtomValue } from "jotai";
+import { useDeleteUploadedFileOneByOne } from "@/hooks/fileUploader/useDeleteUploadedFileOneByOne";
 import { useDropAndUploadFiles } from "@/hooks/fileUploader/useDropAndUploadFiles";
 import { useHoverFile } from "@/hooks/fileUploader/useHoverFile";
-
 type CarouselSliderProps = {
   // eslint-disable-next-line no-unused-vars
   handleSelectedFile: (file: UploadedFile) => void;
   selectedImage: string | null;
-}
+};
 //
-export const CarouselSlider = ({ handleSelectedFile, selectedImage }: CarouselSliderProps) => {
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
-
-  const setUploadedImages = useSetAtom(uploadedFilesAtom);
+export const CarouselSlider = ({
+  handleSelectedFile,
+  selectedImage,
+}: CarouselSliderProps) => {
+  const uploadedResources = useAtomValue(uploadedFilesAtom);
   const { isCurrentHoveredFile, handleMouseOver, handleMouseLeave } =
     useHoverFile();
   const { imageDropZone, documentDropZone } = useDropAndUploadFiles();
-
-  const handleRemoveFile = useAtomCallback(
-    useCallback(
-      (get, set, arg: { id: string, type: string, name: string }) => {
-        const remainingImages = get(uploadedFilesAtom).filter(
-          (file) => file.id !== arg.id
-        );
-
-        if (remainingImages) {
-          !arg.type.startsWith("image/")
-            ? deleteStorageFile(arg?.name, "documents")
-            : deleteStorageFile(arg?.name, "images");
-          setUploadedImages(remainingImages);
-        }
-      },
-      [setUploadedImages]
-    )
-  );
+  const { handleRemoveFile } = useDeleteUploadedFileOneByOne();
 
   //
   return (
     <div className="mt-6 flex items-center justify-center space-x-2">
       <ul className="scrollbar flex max-w-[72rem] space-x-2 overflow-x-scroll scroll-smooth px-2">
-        {uploadedImages.map((file, index) => (
+        {uploadedResources.map((file, index) => (
           <li
             role="button"
             key={file?.id}
@@ -103,8 +84,8 @@ export const CarouselSlider = ({ handleSelectedFile, selectedImage }: CarouselSl
           </li>
         ))}
       </ul>
-      {uploadedImages.length > 0 &&
-        uploadedImages[0]?.type.startsWith("image/") ? (
+      {uploadedResources.length > 0 &&
+      uploadedResources[0]?.type.startsWith("image/") ? (
         <div className="h-14 self-start">
           <button
             {...imageDropZone.getRootProps()}

--- a/components/messaging/carousel/CarouselWrapper.tsx
+++ b/components/messaging/carousel/CarouselWrapper.tsx
@@ -23,7 +23,7 @@ import { useSendOutboundMessage } from "@/hooks/messaging/useSendOutboundMessage
 
 export const CarouselWrapper = () => {
   const editorWithImages = useEditorWithImages();
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
+  const uploadedResources = useAtomValue(uploadedFilesAtom);
   const handleDeleteAllFiles = useDeleteAllUploadedFiles();
   const { handleSelectedFile, selectedFile } = useSelectedUploadedFile();
 
@@ -58,39 +58,47 @@ export const CarouselWrapper = () => {
             </button>
           </div>
           <div className="relative h-[60vh] w-full">
-            {progress > 0 && progress !== 100 && (<div>Upload is in progres...</div>)}
-            {uploadedImages && uploadedImages.length > 0 && progress === 100 && areAllFilesTypeOfImage(uploadedImages) && (
-              <Image
-                className="absolute top-0 h-full w-full rounded-sm object-contain drop-shadow-md"
-                src={currentSelectedFile(uploadedImages, selectedFile)}
-                alt="file preview"
-                fill
-                sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 800px"
-              />
+            {progress > 0 && progress !== 100 && (
+              <div>Upload is in progres...</div>
             )}
-
-            {uploadedImages && uploadedImages.length > 0 && progress === 100 && !areAllFilesTypeOfImage(uploadedImages) && (
-              <div className="relative flex h-full w-full flex-col items-center justify-center">
-                <ShowFileTypeIcon
-                  fileType={getFileExtensionFromName(
-                    uploadedImages,
-                    selectedFile
-                  )}
-                  classString="mx-auto h-60 w-60 text-slate-300"
+            {uploadedResources &&
+              uploadedResources.length > 0 &&
+              progress === 100 &&
+              areAllFilesTypeOfImage(uploadedResources) && (
+                <Image
+                  className="absolute top-0 h-full w-full rounded-sm object-contain drop-shadow-md"
+                  src={currentSelectedFile(uploadedResources, selectedFile)}
+                  alt="file preview"
+                  fill
+                  sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 800px"
                 />
+              )}
 
-                <h3 className="mt-12 text-xl font-semibold text-slate-700">
-                  {getNameFromFile(uploadedImages, selectedFile)}
-                </h3>
-                <p className="mt-2 text-base font-medium text-slate-500">
-                  {calculateFileSize(uploadedImages, selectedFile)} -{" "}
-                  {getFileExtensionFromName(
-                    uploadedImages,
-                    selectedFile
-                  )?.toUpperCase()}
-                </p>
-              </div>
-            )}
+            {uploadedResources &&
+              uploadedResources.length > 0 &&
+              progress === 100 &&
+              !areAllFilesTypeOfImage(uploadedResources) && (
+                <div className="relative flex h-full w-full flex-col items-center justify-center">
+                  <ShowFileTypeIcon
+                    fileType={getFileExtensionFromName(
+                      uploadedResources,
+                      selectedFile
+                    )}
+                    classString="mx-auto h-60 w-60 text-slate-300"
+                  />
+
+                  <h3 className="mt-12 text-xl font-semibold text-slate-700">
+                    {getNameFromFile(uploadedResources, selectedFile)}
+                  </h3>
+                  <p className="mt-2 text-base font-medium text-slate-500">
+                    {calculateFileSize(uploadedResources, selectedFile)} -{" "}
+                    {getFileExtensionFromName(
+                      uploadedResources,
+                      selectedFile
+                    )?.toUpperCase()}
+                  </p>
+                </div>
+              )}
           </div>
           <div>
             {`${progress}%`}

--- a/hooks/fileUploader/useDeleteAllUploadedFiles.ts
+++ b/hooks/fileUploader/useDeleteAllUploadedFiles.ts
@@ -11,7 +11,7 @@ import { useSetAtom } from "jotai";
 
 //
 export const useDeleteAllUploadedFiles = () => {
-  const setUploadedImages = useSetAtom(uploadedFilesAtom);
+  const setUploadedResources = useSetAtom(uploadedFilesAtom);
   const setProgressAtom = useSetAtom(progressPercentageAtom);
   const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
 
@@ -21,6 +21,12 @@ export const useDeleteAllUploadedFiles = () => {
       async (get) => {
         const filePromises: any = [];
         const files = get(uploadedFilesAtom);
+
+        const resetProgressAndNumberOfUploadedFiles = () => {
+          setUploadedResources([]);
+          setProgressAtom(0);
+          setNumberOfFilesUploaded(0);
+        };
 
         if (!files) return;
         if (files.length === 0) return;
@@ -40,11 +46,9 @@ export const useDeleteAllUploadedFiles = () => {
           }
         });
         await Promise.all(filePromises);
-        setUploadedImages([]);
-        setProgressAtom(0);
-        setNumberOfFilesUploaded(0);
+        resetProgressAndNumberOfUploadedFiles();
       },
-      [setUploadedImages, setProgressAtom, setNumberOfFilesUploaded]
+      [setUploadedResources, setProgressAtom, setNumberOfFilesUploaded]
     )
   );
 

--- a/hooks/fileUploader/useDeleteUploadedFileOneByOne.ts
+++ b/hooks/fileUploader/useDeleteUploadedFileOneByOne.ts
@@ -1,0 +1,50 @@
+import {
+  numberOfFilesUploadedAtom,
+  progressPercentageAtom,
+  uploadedFilesAtom,
+} from "@/lib/state/atoms";
+
+import { deleteStorageFile } from "@/utils/deleteStorageFile";
+import { useAtomCallback } from "jotai/utils";
+import { useCallback } from "react";
+import { useSetAtom } from "jotai";
+
+export const useDeleteUploadedFileOneByOne = () => {
+  const setProgressAtom = useSetAtom(progressPercentageAtom);
+  const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
+
+  const setUploadedResources = useSetAtom(uploadedFilesAtom);
+
+  const handleRemoveFile = useAtomCallback(
+    useCallback(
+      (get, set, arg: { id: string; type: string; name: string }) => {
+        const remainingResources = get(uploadedFilesAtom).filter(
+          (file) => file.id !== arg.id
+        );
+
+        const resetProgressAndNumberOfUploadedFiles = () => {
+          setProgressAtom(0);
+          setNumberOfFilesUploaded(0);
+        };
+
+        if (remainingResources) {
+          !arg.type.startsWith("image/")
+            ? deleteStorageFile(arg?.name, "documents").then(() => {
+                if (remainingResources.length === 0) {
+                  resetProgressAndNumberOfUploadedFiles();
+                }
+              })
+            : deleteStorageFile(arg?.name, "images").then(() => {
+                if (remainingResources.length === 0) {
+                  resetProgressAndNumberOfUploadedFiles();
+                }
+              });
+          setUploadedResources(remainingResources);
+        }
+      },
+      [setUploadedResources, setProgressAtom, setNumberOfFilesUploaded]
+    )
+  );
+
+  return { handleRemoveFile };
+};

--- a/hooks/insurance_company/useCreateNewCompany.ts
+++ b/hooks/insurance_company/useCreateNewCompany.ts
@@ -15,10 +15,10 @@ import { useForm } from "react-hook-form";
 
 //
 export const useCreateNewCompany = () => {
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
+  const uploadedResources = useAtomValue(uploadedFilesAtom);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [openModal, setOpenModal] = useState(false);
-  const setUploadedImages = useSetAtom(uploadedFilesAtom);
+  const setUploadedResources = useSetAtom(uploadedFilesAtom);
   const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
   const setProgressPercentage = useSetAtom(progressPercentageAtom);
   const {
@@ -39,7 +39,7 @@ export const useCreateNewCompany = () => {
 
   const createCompany = (companyDetails: InsuranceCompany) => {
     const { notes, name } = companyDetails;
-    const logoUrl = uploadedImages.find(
+    const logoUrl = uploadedResources.find(
       (file) =>
         file.type.startsWith("image/") &&
         file?.url?.includes("insurance_company_logos")
@@ -54,7 +54,7 @@ export const useCreateNewCompany = () => {
         reset();
         setNumberOfFilesUploaded(0);
         setProgressPercentage(0);
-        setUploadedImages([]);
+        setUploadedResources([]);
         handleCloseModal();
         setIsSubmitting(false);
         successNotification(
@@ -64,7 +64,7 @@ export const useCreateNewCompany = () => {
       .catch((err) => {
         setNumberOfFilesUploaded(0);
         setProgressPercentage(0);
-        setUploadedImages([]);
+        setUploadedResources([]);
         handleCloseModal();
         setIsSubmitting(false);
         failureNotification(

--- a/hooks/insurance_company/useUpdateCompany.ts
+++ b/hooks/insurance_company/useUpdateCompany.ts
@@ -19,10 +19,10 @@ import { useForm } from "react-hook-form";
 
 //
 export const useUpdateCompany = () => {
-  const uploadedImages = useAtomValue(uploadedFilesAtom);
+  const uploadedResources = useAtomValue(uploadedFilesAtom);
   const [isSubmitting, setIsSubmitting] = useAtom(isSubmittingAtom);
   const [openModal, setOpenModal] = useAtom(openModalAtom);
-  const setUploadedImages = useSetAtom(uploadedFilesAtom);
+  const setUploadedResources = useSetAtom(uploadedFilesAtom);
   const setSelectedInsuranceCompany = useSetAtom(selectedInsuranceCompanyAtom);
   const selectedInsuranceCompany = useAtomValue(selectedInsuranceCompanyAtom);
   const setNumberOfFilesUploaded = useSetAtom(numberOfFilesUploadedAtom);
@@ -60,7 +60,7 @@ export const useUpdateCompany = () => {
 
   const updateCompany = (updatedCompany: FieldValues) => {
     const { notes, name, logo_url } = updatedCompany;
-    const logoUrl = uploadedImages.find(
+    const logoUrl = uploadedResources.find(
       (file) =>
         file.type.startsWith("image/") &&
         file?.url?.includes("insurance_company_logos")
@@ -80,7 +80,7 @@ export const useUpdateCompany = () => {
         reset();
         setNumberOfFilesUploaded(0);
         setProgressPercentage(0);
-        setUploadedImages([]);
+        setUploadedResources([]);
         handleCloseModal();
         setIsSubmitting(false);
         successNotification(
@@ -92,7 +92,7 @@ export const useUpdateCompany = () => {
       .catch((err) => {
         setNumberOfFilesUploaded(0);
         setProgressPercentage(0);
-        setUploadedImages([]);
+        setUploadedResources([]);
         handleCloseModal();
         setIsSubmitting(false);
         failureNotification(


### PR DESCRIPTION
The Transition JSX element was remaining open because progress wasn't set back to zero if files were deleted one by one after being uploaded successfully. 
I also renamed the `uploadedImages` var to `uploadedResources` to make it less obvious to images only, since this will hold images or files uploaded to firebase storage. 

Also, I refactored some code into a new hook named `useDeleteUploadedFilesOneByOne`