### PR TITLE
bug: forgot to add the middleware API routes

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -9,6 +9,7 @@ const publicPaths = [
   "/sms-notifications*",
   "/sms-campaign*",
   "/sign_pdf*",
+  "/api/documents*",
 ];
 
 const isPublic = (path) => {


### PR DESCRIPTION
API routes related to PDF documents should be able to be called without clerk middleware