### PR TITLE
fix: using the edge serverless fn instead

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,3 +1,6 @@
+export const runtime = "edge";
+export const dynamic = "force-dynamic"; // static by default, unless reading the request
+
 export async function GET(request: Request) {
   const requestHeaders = new Headers(request.headers);
   const { searchParams } = new URL(request.url);


### PR DESCRIPTION
The default runtime in Vercel for serverless is `nodejs` which timeouts at 10s. 
Switching to `edge` runtime to see if it allows more than 10 sec according to the Vercel docs. 